### PR TITLE
fix: use dynamic MEMORY_DIR from plugin context

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { type Plugin, tool } from "@opencode-ai/plugin"
 
-const MEMORY_DIR = ".opencode/memory"
+let MEMORY_DIR = ".opencode/memory"
 
 const getMemoryFile = () => {
   const date = new Date().toISOString().split("T")[0]
@@ -345,6 +345,7 @@ const forget = tool({
 })
 
 export const MemoryPlugin: Plugin = async (_ctx) => {
+  MEMORY_DIR = `${_ctx.directory}/.opencode/memory`
   return {
     tool: {
       memory_remember: remember,


### PR DESCRIPTION
Enables the memory plugin to work correctly across different workspace directories by using the directory from plugin context instead of a hardcoded path. This allows the plugin to function properly in environments like VS Code extensions.

Closes #4 